### PR TITLE
Match saving and alternate start

### DIFF
--- a/McIntoshHotshots/Components/Pages/LiveScoring.razor
+++ b/McIntoshHotshots/Components/Pages/LiveScoring.razor
@@ -48,7 +48,7 @@
             
             <!-- Game Status -->
             <div class="game-status">
-                <div class="current-leg">@currentMatch.HomeLegsWon - @currentMatch.AwayLegsWon SETS</div>
+                <div class="current-leg">@currentMatch.HomeLegsWon - @currentMatch.AwayLegsWon Leg Count</div>
                 <div class="player-turn">@currentMatch.GetPlayerName(currentMatch.CurrentPlayerId)</div>
                 <div class="dart-indicators">
                     @for (int i = 1; i <= 3; i++)

--- a/McIntoshHotshots/Components/Pages/LiveScoring.razor
+++ b/McIntoshHotshots/Components/Pages/LiveScoring.razor
@@ -117,9 +117,10 @@
                         </div>
                         
                         <div class="input-actions">
-                            <button class="action-btn clear" @onclick="ClearInput">Clear</button>
-                            <button class="action-btn undo" @onclick="UndoLastThrow">Undo</button>
-                            <button class="action-btn submit" @onclick="() => RecordScore(inputScore)" 
+                            <button class="action-btn @(inputScore > 0 ? "clear" : "undo")" @onclick="UndoOrClearAction">
+                                @(inputScore > 0 ? "Clear" : "Undo")
+                            </button>
+                            <button class="action-btn submit" @onclick="() => RecordScore(inputScore)"
                                     disabled="@(!CanRecordScore() || inputScore < 0 || inputScore > 180)">
                                 Submit
                             </button>
@@ -387,6 +388,20 @@
         await RecordScore(score);
     }
     
+    private async Task UndoOrClearAction()
+    {
+        if (inputScore > 0)
+        {
+            // Clear the current input
+            ClearInput();
+        }
+        else
+        {
+            // Undo the last throw
+            await UndoLastThrow();
+        }
+    }
+
     private async Task UndoLastThrow()
     {
         if (currentMatch != null)

--- a/McIntoshHotshots/Services/LiveMatchService.cs
+++ b/McIntoshHotshots/Services/LiveMatchService.cs
@@ -189,8 +189,8 @@ public class LiveMatchService : ILiveMatchService
             match.DartsThrown = 0;
             match.CurrentTurnScores.Clear();
             
-            // Switch starting player
-            match.CurrentPlayerId = match.CurrentPlayerId == match.HomePlayerId ? match.AwayPlayerId : match.HomePlayerId;
+            // Alternate starting player: home starts odd legs, away starts even legs
+            match.CurrentPlayerId = match.CurrentLegNumber % 2 == 1 ? match.HomePlayerId : match.AwayPlayerId;
         }
         
         return await Task.FromResult(match);
@@ -214,7 +214,8 @@ public class LiveMatchService : ILiveMatchService
             HomeLegsWon = match.HomeLegsWon,
             AwayLegsWon = match.AwayLegsWon,
             TimeElapsed = (DateTime.UtcNow - match.StartTime).ToString(@"hh\:mm\:ss"),
-            TournamentId = match.TournamentId
+            TournamentId = match.TournamentId,
+            UrlToRecap = "/recap/placeholder"
         };
         
         // Save to database

--- a/McIntoshHotshots/Services/LiveMatchService.cs
+++ b/McIntoshHotshots/Services/LiveMatchService.cs
@@ -153,11 +153,11 @@ public class LiveMatchService : ILiveMatchService
         {
             match.CurrentPlayerId = lastThrow.PlayerId;
             // If we're switching back to previous player, we need to restore their turn state
-            var remainingThrowsInTurn = match.AllThrows.Where(t =>
+            var remainingDartsInTurn = match.AllThrows.Where(t =>
                 t.LegNumber == match.CurrentLegNumber &&
                 t.TurnNumber == lastThrow.TurnNumber &&
-                t.PlayerId == lastThrow.PlayerId).Count();
-            match.DartsThrown = remainingThrowsInTurn;
+                t.PlayerId == lastThrow.PlayerId).Sum(t => t.DartsUsed);
+            match.DartsThrown = remainingDartsInTurn;
             match.CurrentTurnNumber = lastThrow.TurnNumber;
 
             // Rebuild current turn scores for the restored player

--- a/McIntoshHotshots/Services/LiveMatchService.cs
+++ b/McIntoshHotshots/Services/LiveMatchService.cs
@@ -127,25 +127,48 @@ public class LiveMatchService : ILiveMatchService
     {
         if (!_activeMatches.TryGetValue(matchId, out var match))
             return false;
-            
-        var lastThrow = match.AllThrows.LastOrDefault(t => t.PlayerId == playerId && t.LegNumber == match.CurrentLegNumber);
+
+        // Get the absolute last throw in the current leg, regardless of which player threw it
+        var lastThrow = match.AllThrows.LastOrDefault(t => t.LegNumber == match.CurrentLegNumber);
         if (lastThrow == null)
             return false;
-            
+
         // Remove the throw
         match.AllThrows.Remove(lastThrow);
-        
-        // Restore score
-        if (playerId == match.HomePlayerId)
+
+        // Restore score for the player who actually threw it
+        if (lastThrow.PlayerId == match.HomePlayerId)
             match.HomeCurrentScore = lastThrow.ScoreRemainingBefore;
         else
             match.AwayCurrentScore = lastThrow.ScoreRemainingBefore;
-            
-        // Adjust turn state
+
+        // Adjust turn state - check if we need to switch back to the previous player
         match.DartsThrown -= lastThrow.DartsUsed;
         if (match.CurrentTurnScores.Any())
             match.CurrentTurnScores.RemoveAt(match.CurrentTurnScores.Count - 1);
-            
+
+        // If undoing changed the current player (because we undid the other player's throw),
+        // we need to switch back to that player and adjust the turn state
+        if (lastThrow.PlayerId != match.CurrentPlayerId)
+        {
+            match.CurrentPlayerId = lastThrow.PlayerId;
+            // If we're switching back to previous player, we need to restore their turn state
+            var remainingThrowsInTurn = match.AllThrows.Where(t =>
+                t.LegNumber == match.CurrentLegNumber &&
+                t.TurnNumber == lastThrow.TurnNumber &&
+                t.PlayerId == lastThrow.PlayerId).Count();
+            match.DartsThrown = remainingThrowsInTurn;
+            match.CurrentTurnNumber = lastThrow.TurnNumber;
+
+            // Rebuild current turn scores for the restored player
+            match.CurrentTurnScores.Clear();
+            var currentTurnThrows = match.AllThrows.Where(t =>
+                t.LegNumber == match.CurrentLegNumber &&
+                t.TurnNumber == lastThrow.TurnNumber &&
+                t.PlayerId == lastThrow.PlayerId).Select(t => t.Score).ToList();
+            match.CurrentTurnScores.AddRange(currentTurnThrows);
+        }
+
         return await Task.FromResult(true);
     }
     


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Match summaries now include a recap URL for quick post-game review.
  * Starting player alternates by leg (Home on odd legs, Away on even legs).

* **Bug Fixes / Improvements**
  * Improved Undo: removes the absolute last throw and correctly restores prior player/turn state and scores.

* **UI**
  * Game Status label updated from “SETS” to “Leg Count”.
  * Clear and Undo combined into a single toggle button (clears input or undoes last throw).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->